### PR TITLE
Motor precision bug fix

### DIFF
--- a/darling/_dataset.py
+++ b/darling/_dataset.py
@@ -282,7 +282,7 @@ class DataSet(object):
         self.mean, self.covariance = None, None
         self.mean_3d, self.covariance_3d = None, None
 
-    def load_scan(self, args, scan_id, roi=None):
+    def load_scan(self, args, scan_id, roi=None, scan_size=None):
         """Load a scan into RM.
 
         NOTE: Input args should match the darling.reader.Reader used, however it was implemented.
@@ -298,12 +298,14 @@ class DataSet(object):
             roi (:obj:`tuple` of :obj:`int`): row_min row_max and column_min and column_max,
                 defaults to None, in which case all data is loaded. The roi refers to the detector
                 dimensions.
+            scan_size (:obj:`tuple` of :obj:`int`): The size of the scan in the detector dimensions.
+             
 
         """
         if isinstance(args, tuple):
-            self.data, self.motors = self.reader(*args, scan_id, roi)
+            self.data, self.motors = self.reader(*args, scan_id, roi, scan_size)
         else:
-            self.data, self.motors = self.reader(args, scan_id, roi)
+            self.data, self.motors = self.reader(args, scan_id, roi, scan_size)
 
     def subtract(self, value):
         """Subtract a fixed integer value form the data. Protects against uint16 sign flips.

--- a/darling/_dataset.py
+++ b/darling/_dataset.py
@@ -298,8 +298,8 @@ class DataSet(object):
             roi (:obj:`tuple` of :obj:`int`): row_min row_max and column_min and column_max,
                 defaults to None, in which case all data is loaded. The roi refers to the detector
                 dimensions.
-            scan_size (:obj:`tuple` of :obj:`int`): The size of the scan in the detector dimensions.
-             
+            scan_size (:obj:`tuple` of :obj:`int`): The size of the scan in the motor dimensions.
+
 
         """
         if isinstance(args, tuple):

--- a/darling/reader.py
+++ b/darling/reader.py
@@ -175,7 +175,7 @@ class EnergyScan(Reader):
             dname = data_name
         return dname, mnames
 
-    def __call__(self, data_name, scan_id, roi=None):
+    def __call__(self, data_name, scan_id, roi=None, scan_size=None):
         """Load a scan
 
         this loads the mosa data array with shape N,N,m,n where N is the detector dimension and
@@ -187,6 +187,10 @@ class EnergyScan(Reader):
             scan_id (:obj:`str`):scan id to load from, e.g 1.1, 2.1 etc...
             roi (:obj:`tuple` of :obj:`int`): row_min row_max and column_min and column_max,
                 defaults to None, in which case all data is loaded
+            scan_size (:obj:`tuple` of :obj:`int`): size of the scan in each motor dimension. This is used to,
+                adjust the motors if the precision is not enough to uniquely identify the motor settings. This is
+                a last resort and should be avoided if possible. This should be defined in the same order as the
+                motor_names. This needs to be implemented here.
 
         Returns:
             data, motors : data of shape (a,b,m,n) and motors tuple of len=m and len=n

--- a/darling/reader.py
+++ b/darling/reader.py
@@ -127,7 +127,7 @@ class MosaScan(Reader):
                 )
             except ValueError as e:
                 if scan_size:
-                    print(f"Motor precision issue, trying to fixing by setting the scan size to {scan_size}")
+                    print(f"Motor precision issue, fixing by setting the scan size to {scan_size}")
                     adjusted_motors = []
                     for i, size in enumerate(scan_size):
                         adjusted_motors.append(

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,5 +1,7 @@
 import os
 import unittest
+import tempfile
+import h5py
 
 import matplotlib.pyplot as plt
 import numpy as np


### PR DESCRIPTION
## Summary
This solves an issue where motor dimensions in the dataset occasionally cause a `ValueError` during data reshaping due to motor readout precision errors. A fallback mechanism has been added to allow the use of a `scan_size` parameter as a last resort to resolve these issues. 

This occurs when the number of unique motor values does not match the expected dimensions required for reshaping. A screenshot of the error is included below:
![image](https://github.com/user-attachments/assets/c03cc5a4-bd1e-4a10-9441-ce69f338f120)

The fallback fixes this issue:
![image](https://github.com/user-attachments/assets/35a3e957-f9b4-40ae-81f3-253f4c2f2b70)


I've also added a test where I create a "bad" dataset I wasn't sure how to incorporate it otherwise. 