### PR TITLE
Generalizes the `DataSet.integrate()` method

### DIFF
--- a/darling/_dataset.py
+++ b/darling/_dataset.py
@@ -278,7 +278,8 @@ class DataSet(object):
                 Defaults to np.float32.
 
         Returns:
-            :obj:`numpy.ndarray`: Integrated frames, a 2D numpy array of shape (m, n) with dtype `dtype`.
+            :obj:`numpy.ndarray`: Integrated frames, a 2D numpy array of reduced
+                shape and dtype `dtype`.
         """
         if axis is None:
             out = np.zeros((self.data.shape[0], self.data.shape[1]), dtype=dtype)

--- a/darling/_dataset.py
+++ b/darling/_dataset.py
@@ -265,16 +265,32 @@ class DataSet(object):
         self.kam_kernel_size = size
         return self.kam
 
-    def integrate(self):
-        """Return the summed data stack along the motor dimensions avoiding data stack copying.
+    def integrate(self, axis=None, dtype=np.float32):
+        """Return the summed data stack along the specified axes, avoiding data stack copying.
+
+        If no axis is specified, the integration is performed over all dimensions
+        except the first two, which are assumed to be the detector dimensions.
+
+        Args:
+            axis (:obj:`int` or :obj:`tuple`, optional): The axis or axes along which to integrate.
+                If None, integrates over all axes except the first two.
+            dtype (:obj:`numpy.dtype`, optional): The data type of the output array.
+                Defaults to np.float32.
 
         Returns:
-            (:obj:`numpy array`): integrated frames, a 2D numpy array.
+            :obj:`numpy.ndarray`: Integrated frames, a 2D numpy array of shape (m, n) with dtype `dtype`.
         """
-        out = np.zeros(
-            (self.data.shape[0], self.data.shape[1]), np.float32
-        )  # avoid casting and copying.
-        integrated_frames = np.sum(self.data, axis=(2, 3), out=out)
+        if axis is None:
+            out = np.zeros((self.data.shape[0], self.data.shape[1]), dtype=dtype)
+            integrated_frames = np.sum(
+                self.data, axis=tuple(range(2, self.data.ndim)), out=out
+            )
+        else:
+            shape = list(self.data.shape)
+            for ax in sorted(np.atleast_1d(axis), reverse=True):
+                shape.pop(ax)
+            out = np.zeros(shape, dtype=dtype)
+            integrated_frames = np.sum(self.data, axis=axis, out=out)
         return integrated_frames
 
     def estimate_mask(

--- a/darling/metadata.py
+++ b/darling/metadata.py
@@ -180,12 +180,8 @@ class ID03(object):
         def get_leaf(name, obj):
             leafs.append(name)
 
-
         with h5py.File(self.abs_path_to_h5_file, "r") as h5f:
             h5f[scan_id].visititems(get_leaf)
-
-
-
             while len(leafs) > 0:
                 leaf = leafs.pop()
                 if (


### PR DESCRIPTION
This PR enhances the `DataSet.integrate()` method by adding an `axis` keyword for flexible integration and a dtype keyword for specifying the output `dtype`. Unit tests have been updated accordingly and now include rocking scan data, effectively resolving #13.


# New Signature: 

````python
integrate(axis=None, dtype=np.float32)
````

# Summary:

* Flexible Integration: Supports summing over specified axes. Defaults to integrating all except the first two (assumed detector dimensions).

* Custom Data Type: Output can be cast to a specified dtype (default: np.float32).

* Bug Fix: Rocking scan data handling now works correctly, fixing #13.
